### PR TITLE
fix: DynamoDB 추가 예약어 'dateTime' 처리

### DIFF
--- a/app/db/dynamo.py
+++ b/app/db/dynamo.py
@@ -184,7 +184,6 @@ async def get_weekly_activity_data(user_email: str) -> dict:
     table = dynamodb_client.Table("lookback-calendar-events")
     
     try:
-        # 이번 주의 시작/종료 날짜 계산
         today = datetime.now(pytz.UTC)
         this_week_start = today - timedelta(days=today.weekday())
         this_week_end = this_week_start + timedelta(days=5)
@@ -194,12 +193,13 @@ async def get_weekly_activity_data(user_email: str) -> dict:
 
         logger.info(f"조회 기간 - 시작: {this_week_start}, 종료: {this_week_end}")
         
-        # 예약어 'start'를 피하기 위해 #st 별칭 사용
+        # start와 dateTime 모두 예약어이므로 별칭 처리
         response = table.query(
             KeyConditionExpression='user_id = :uid',
-            FilterExpression='#st.dateTime between :start_date and :end_date',
+            FilterExpression='#st.#dt between :start_date and :end_date',
             ExpressionAttributeNames={
-                '#st': 'start'  # 예약어 'start'에 대한 별칭 정의
+                '#st': 'start',  # start 예약어에 대한 별칭
+                '#dt': 'dateTime'  # dateTime 예약어에 대한 별칭
             },
             ExpressionAttributeValues={
                 ':uid': user_email,


### PR DESCRIPTION
DynamoDB 쿼리에서 'dateTime' 예약어로 인한 ValidationException 추가 발생 ExpressionAttributeNames에 dateTime 별칭 추가하여 해결

- get_weekly_activity_data 함수의 쿼리문 수정
- FilterExpression에서 중첩 속성 접근 방식 수정
- 'dateTime' 키워드를 '#dt' 별칭으로 추가 처리

이전 커밋에서 처리한 'start' 예약어와 함께
'start.dateTime' 형식의 중첩 속성에 대한 올바른 별칭 처리 완료